### PR TITLE
chore: pin checkout@v4 and sibling actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
## Summary
- Replace floating `actions/checkout@v4` (and other floating actions in the same files) with SHA pins, or `actionsforge` reusables (`github-pages-deploy`, `astro-pages-deploy`, `validate-devschema`) where they fit
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass
- [ ] Pages/deploy jobs still trigger as before (if applicable)